### PR TITLE
Fix python3 setup when system encoding is not utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import io
 import os
 import re
 import sys
@@ -32,10 +33,9 @@ def getPackageInfo():
     key_remap = {"name": "pypi_name"}
 
     # __about__
-    with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                           "./src",
-                           "eyed3",
-                           "__about__.py")) as infof:
+    info_fpath = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "src", "eyed3", "__about__.py")
+    with io.open(info_fpath, encoding='utf-8') as infof:
         for line in infof:
             for what in info_keys:
                 rex = re.compile(r"__{what}__\s*=\s*['\"](.*?)['\"]"
@@ -64,11 +64,11 @@ def getPackageInfo():
     # Info
     readme = ""
     if os.path.exists("README.rst"):
-        with open("README.rst") as readme_file:
+        with io.open("README.rst", encoding='utf-8') as readme_file:
             readme = readme_file.read()
     history = ""
     if os.path.exists("HISTORY.rst"):
-        with open("HISTORY.rst") as history_file:
+        with io.open("HISTORY.rst", encoding='utf-8') as history_file:
             history = history_file.read().replace(".. :changelog:", "")
     info_dict["long_description"] = readme + "\n\n" + history
 
@@ -80,7 +80,7 @@ def requirements_yaml():
     reqs = {}
     reqfile = os.path.join("requirements", "requirements.yml")
     if os.path.exists(reqfile):
-        with open(reqfile) as fp:
+        with io.open(reqfile, encoding='utf-8') as fp:
             curr = None
             for line in [l for l in [l.strip() for l in fp.readlines()]
                      if l and not l.startswith("#")]:


### PR DESCRIPTION
Under python3, opening utf-8 files like HISTORY.rst in setup.py causes encoding
error if the default encoding for the system is not utf-8.

This happens for instance on debian reproducible builds where environment has `LC_ALL=C`