### PR TITLE
Fixed bug with improper types when re-rendering unique file ID.

### DIFF
--- a/src/eyed3/id3/frames.py
+++ b/src/eyed3/id3/frames.py
@@ -1021,7 +1021,7 @@ class UniqueFileIDFrame(Frame):
         log.debug("UFID owner_id: %s" % self.owner_id)
         log.debug("UFID id: %s" % self.uniq_id)
         if len(self.owner_id) == 0:
-            dummy_owner_id = "http://www.id3.org/dummy/ufid.html"
+            dummy_owner_id = b"http://www.id3.org/dummy/ufid.html"
             self.owner_id = dummy_owner_id
             core.parseError(FrameException("Invalid UFID, owner_id is empty. "
                                            "Setting to '%s'" % dummy_owner_id))
@@ -1030,7 +1030,7 @@ class UniqueFileIDFrame(Frame):
                                            "long: %s" % self.uniq_id))
 
     def render(self):
-        self.data = self.owner_id + b"\x00" + self.uniq_id
+        self.data = self.owner_id + b"\x00" + b''.join(self.uniq_id)
         return super(UniqueFileIDFrame, self).render()
 
 


### PR DESCRIPTION
I don't know the underlying reasons of why this has been done like that, but under certain conditions, when I try to make a modification to a file that I have, the method render of the class UniqueFileIDFrame fails due to the above listed problems. I ran the following script:

```
#!/usr/local/bin/python3.8

import eyed3

audiofile = eyed3.load("happydays.mp3")
audiofile.tag.title = "01 - " + audiofile.tag.title

audiofile.tag.save()

```
And the result was:

```
Invalid UFID, owner_id is empty. Setting to 'http://www.id3.org/dummy/ufid.html'
Traceback (most recent call last):
  File "./testjp.py", line 8, in <module>
    audiofile.tag.save()
  File "/home/gabriel/Projects/eyeD3/src/eyed3/id3/tag.py", line 823, in save
    self._saveV2Tag(version, encoding, max_padding)
  File "/home/gabriel/Projects/eyeD3/src/eyed3/id3/tag.py", line 1027, in _saveV2Tag
    rewrite_required, tag_data, padding = self._render(version,
  File "/home/gabriel/Projects/eyeD3/src/eyed3/id3/tag.py", line 945, in _render
    raw_frame = f.render()
  File "/home/gabriel/Projects/eyeD3/src/eyed3/id3/frames.py", line 1035, in render
    self.data = self.owner_id + b"\x00" + self.uniq_id
```

You can see that the string 'http://www.id3.org/dummy/ufid.html' should have rather being b'http://www.id3.org/dummy/ufid.html' because it need to be concatenated to another byte array later, besides that, even after if this is fixed, the uniq_id is a list instead of another byte array, so joining it should solve at least this issue.

I have a patch that solves this issue here:

```
diff --git a/src/eyed3/id3/frames.py b/src/eyed3/id3/frames.py
index e48f82c..771446f 100644
--- a/src/eyed3/id3/frames.py
+++ b/src/eyed3/id3/frames.py
@@ -1021,7 +1021,7 @@ class UniqueFileIDFrame(Frame):
         log.debug("UFID owner_id: %s" % self.owner_id)
         log.debug("UFID id: %s" % self.uniq_id)
         if len(self.owner_id) == 0:
-            dummy_owner_id = "http://www.id3.org/dummy/ufid.html"
+            dummy_owner_id = b"http://www.id3.org/dummy/ufid.html"
             self.owner_id = dummy_owner_id
             core.parseError(FrameException("Invalid UFID, owner_id is empty. "
                                            "Setting to '%s'" % dummy_owner_id))
@@ -1030,7 +1030,7 @@ class UniqueFileIDFrame(Frame):
                                            "long: %s" % self.uniq_id))
 
     def render(self):
-        self.data = self.owner_id + b"\x00" + self.uniq_id
+        self.data = self.owner_id + b"\x00" + b''.join(self.uniq_id)
         return super(UniqueFileIDFrame, self).render()

```
Unfortunately I coudn't find a way to upload the mp3 file used for the test. Anyone wanting it, just share it with me.

Regards,
Gabriel