### PR TITLE
remove warning from Genre name property that prints to stdout when us…

### DIFF
--- a/src/eyed3/id3/__init__.py
+++ b/src/eyed3/id3/__init__.py
@@ -208,7 +208,7 @@ class Genre:
             # normalize the name
             self._name = genres[self._id]
         else:
-            log.warning("Non standard genre name: %s" % val)
+            # log.warning("Non standard genre name: %s" % val)
             self._id = None
             self._name = val
 


### PR DESCRIPTION
…ing a non-standard genre name

to reproduce bug, load any mp3, create a new Genre by parsing a non-standard name, and assign it to track.tag.genre.

