### PR TITLE
Date correctness between ID3 versions

### DIFF
--- a/eyed3/id3/frames.py
+++ b/eyed3/id3/frames.py
@@ -376,12 +376,13 @@ class DateFrame(TextFrame):
         try:
             if type(date) is str:
                 date = core.Date.parse(date)
-            elif type(date) is str:
-                date = core.Date.parse(date.encode("latin1"))
+            elif type(date) is int:
+                # Date is year
+                date = core.Date(date)
             elif not isinstance(date, core.Date):
-                raise TypeError("str or eyed3.core.Date type expected")
+                raise TypeError("str, int, or eyed3.core.Date type expected")
         except ValueError:
-            log.warning("Invalid date text: %s" % date)
+            log.warning(f"Invalid date text: {date}")
             self.text = ""
             return
 

--- a/eyed3/id3/tag.py
+++ b/eyed3/id3/tag.py
@@ -28,16 +28,6 @@ ID3_V1_COMMENT_DESC = "ID3v1.x Comment"
 ID3_V1_MAX_TEXTLEN = 30
 DEFAULT_PADDING = 256
 
-"""dates2020
-v2.3    v2.4   eyeD3
-====    ====   ======
-TORY    TDOR   original_release_date
-        TDRL   release_date
-TYER+   TDRC   recording_date
-TDAT+
-TIME
-"""
-
 
 class Tag(core.Tag):
     def __init__(self, **kwargs):
@@ -483,13 +473,13 @@ class Tag(core.Tag):
 
     def _getReleaseDate(self):
         if self.version == ID3_V2_3:
-            return None
+            return self._getV23OrignalReleaseDate()
         else:
             return self._getDate(b"TDRL")
 
     def _setReleaseDate(self, date):
         if self.version == ID3_V2_3:
-            raise ValueError("Release date not supported in ID3 v2.3; see original release date.")
+            self._setDate(b"TORY", date)
         else:
             self._setDate(b"TDRL", date)
 

--- a/eyed3/plugins/classic.py
+++ b/eyed3/plugins/classic.py
@@ -862,7 +862,7 @@ optional. For example, 2012-03 is valid, 2012--12 is not.
         if self.args.release_year is not None:
             # empty string means clean, None means not given
             year = self.args.release_year
-            printWarning("Setting release year: %s" % year)
+            printWarning(f"Setting release year: {year}")
             tag.release_date = int(year) if year else None
             retval = True
 

--- a/test/id3/test_frames.py
+++ b/test/id3/test_frames.py
@@ -202,13 +202,6 @@ def test_DateFrame():
         date.date = d
         assert not date.date
 
-        try:
-            date.date = 9
-        except TypeError:
-            pass
-        else:
-            pytest.fail("TypeError not thrown")
-
 
 def test_compression():
     f = open(__file__, "rb")

--- a/test/id3/test_tag.py
+++ b/test/id3/test_tag.py
@@ -123,13 +123,12 @@ def testTagDates():
         tag.tagging_date = str(date)
         assert (tag.tagging_date == date)
 
-
-        try:
-            tag._setDate(2.4)
-        except TypeError:
-            pass # expected
-        else:
-            assert not("Invalid date type, expected TypeError")
+    try:
+        tag._setDate(b"TDRL", 2.4)
+    except TypeError:
+        pass # expected
+    else:
+        assert not("Invalid date type, expected TypeError")
 
 
 def testTagComments():
@@ -1262,3 +1261,57 @@ def testNumStringConvert():
 
     t.disc_num = ("2", "6")
     assert t.disc_num == (2, 6)
+
+
+def testReleaseDate_v23_v24():
+    """v23 does not have release date, only original release date."""
+    date = Date.parse("1980-07-03")
+    date2 = Date.parse("1926-07-05")
+    year = Date(1966)
+
+    tag = Tag()
+    assert tag.version == ID3_DEFAULT_VERSION
+
+    tag.version = ID3_V2_3
+    assert tag.version == ID3_V2_3
+
+    # Setting release date sets original release date
+    # v2.3 TORY get the year, XDOR get the full date; getter prefers XDOR
+    tag.release_date = "2020-03-08"
+    assert b"TORY" in tag.frame_set
+    assert b"XDOR" in tag.frame_set
+    assert tag.release_date == Date.parse("2020-03-08")
+    assert tag.original_release_date == Date(year=2020, month=3, day=8)
+
+    # Setting original release date sets release date
+    tag.original_release_date = year
+    assert tag.original_release_date == Date(1966)
+    assert tag.release_date == Date.parse("1966")
+    assert b"TORY" in tag.frame_set
+    # Year only value should clean up XDOR
+    assert b"XDOR" not in tag.frame_set
+
+    # Version convert to 2.4 converts original release date only
+    tag.release_date = date
+    assert b"TORY" in tag.frame_set
+    assert b"XDOR" in tag.frame_set
+    assert tag.original_release_date == date
+    assert tag.release_date == date
+    tag.version = ID3_V2_4
+    assert tag.original_release_date == date
+    assert tag.release_date is None
+
+    # v2.4 has both date types
+    tag.release_date = date2
+    assert tag.original_release_date == date
+    assert tag.release_date == date2
+    assert b"TORY" not in tag.frame_set
+    assert b"XDOR" not in tag.frame_set
+
+    # Convert back to 2.3 loses release date, only the year is copied to TORY
+    tag.version = ID3_V2_3
+    assert b"TORY" in tag.frame_set
+    assert b"XDOR" in tag.frame_set
+    assert tag.original_release_date == date
+    assert tag.release_date == Date.parse(str(date))
+

--- a/test/test_classic_plugin.py
+++ b/test/test_classic_plugin.py
@@ -86,8 +86,8 @@ class TestDefaultPlugin(unittest.TestCase):
                 assert retval == 0
 
             af = eyed3.load(self.test_file)
-            assert  af is not None
-            assert  af.tag is not None
+            assert af is not None
+            assert af.tag is not None
             assert af.tag.artist == "The Cramps"
 
     def testNewTagComposer(self, version=id3.ID3_DEFAULT_VERSION):


### PR DESCRIPTION
### Release date vs original release date

#### Getters
tag.release_date -> TDRL (v2.4) , XDOR if XDOR else TORY (v2.3)
tag.original_release -> TDOR (v2.4), XDOR if XDOR else TORY (v2.3)
tag.recording_date -> TDRC (v2.4), TYER+TDAT+TIME (v2.3)

#### Setters
tag.release_date -> TDRL (v2.4) , XDOR if date.month, TORY (date.year) (v2.3)
tag.original_release -> TDOR (v2.4), XDOR if date.month, TORY (date.year) (v2.3)
tag.recording_date -> TDRC (v2.4), TYER+TDAT+TIME (v2.3)

#### Converting v2.4 -- > v2.3
TDOR -> TORY (drop TDRL if present) or TDRL -> TORY, create XDOR if date.month
TDRC -> TYER+TDAT+TIME

#### Converting v2.3 -- > v2.4
XDOR (or TORY) -> TDOR
TYER+TDAT+TIME -> TDRC

### Other dates
TDEN (v2.4), ?? (v2.3), encoding date
TDTG v(2.4), ?? v(2.3), tagging time