### PR TITLE
encode chapter related ids from str to bytes

### DIFF
--- a/eyed3/id3/frames.py
+++ b/eyed3/id3/frames.py
@@ -1271,10 +1271,17 @@ class TocFrame(Frame):
         if self.ordered:
             flags[self.ORDERED_FLAG_BIT] = 1
 
-        data = (self.element_id + b'\x00' +
+        el_id = self.element_id
+        if type(el_id) == str:
+            el_id = self.element_id.encode('latin1', 'replace')
+
+        data = (el_id + b'\x00' +
                 bin2bytes(flags) + dec2bytes(len(self.child_ids)))
 
         for cid in self.child_ids:
+            if type(cid) == str:
+                cid = cid.encode('latin1', 'replace')
+
             data += cid + b'\x00'
 
         if self.description is not None:
@@ -1665,7 +1672,10 @@ class ChapterFrame(Frame):
             self.sub_frames = FrameSet()
 
     def render(self):
-        data = self.element_id + b'\x00'
+        el_id = self.element_id
+        if type(el_id) == str:
+            el_id = self.element_id.encode('latin1', 'replace')
+        data = el_id + b'\x00'
 
         for n in self.times + self.offsets:
             if n is not None:


### PR DESCRIPTION
Don't pull. This was my work around but may offer some insight into a pain point.
But I don't think it solves the underlying issues.

When trying to run `examples/chapters.py` I was hitting errors like `TypeError: can only concatenate str (not "bytes") to str` and the like. I think the real issue is maybe the example is out dated and need to be passing in byte strings instead of strings.
or that the `utils/requireBytes` decorator should be applied more thoroughly to the `ChapterFrame` and `TocFrame` constructors.

