### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/plugins/classic_plugin.rst
+++ b/docs/plugins/classic_plugin.rst
@@ -351,7 +351,7 @@ a single value. Take for example the ``--add-image`` option::
   --add-image IMG_PATH:TYPE[:DESCRIPTION]
 
 This option has 3 pieced of information where one (DESCRIPTION) is optional
-(denoted by the square brackets). Each invidual value is seprated by a ':' like
+(denoted by the square brackets). Each individual value is seprated by a ':' like
 so:
 
 .. code-block:: bash

--- a/docs/plugins/fixup_plugin.rst
+++ b/docs/plugins/fixup_plugin.rst
@@ -48,7 +48,7 @@ The following test and fixes always apply:
 
 Album types:
 
-    - ``lp``: A traditinal "album" of songs from a single artist.
+    - ``lp``: A traditional "album" of songs from a single artist.
       No extra info is written to the tag since this is the default.
     - ``ep``: A short collection of songs from a single artist. The string 'ep'
       is written to the tag's ``eyeD3#album_type`` field.
@@ -75,7 +75,7 @@ Options
     - Type ``various``: ${track:num} - ${artist} - ${title} - Type ``single``: ${artist} - ${title} - All other types: ${artist} -
     ${track:num} - ${title} - A rename template can be supplied in --file-rename-pattern 12. Directories are renamed as follows: -
     Type ``live``: ${best_date:prefer_recording} - ${album} - All other types: ${best_date:prefer_release} - ${album} - A rename
-    template can be supplied in --dir-rename-pattern Album types: - ``lp``: A traditinal "album" of songs from a single artist. No
+    template can be supplied in --dir-rename-pattern Album types: - ``lp``: A traditional "album" of songs from a single artist. No
     extra info is written to the tag since this is the default. - ``ep``: A short collection of songs from a single artist. The
     string 'ep' is written to the tag's ``eyeD3#album_type`` field. - ``various``: A collection of songs from different artists. The
     string 'various' is written to the tag's ``eyeD3#album_type`` field. - ``live``: A collection of live recordings from a single

--- a/eyed3/id3/frames.py
+++ b/eyed3/id3/frames.py
@@ -1734,7 +1734,7 @@ class FrameSet(dict):
     def parse(self, f, tag_header, extended_header):
         """Read frames starting from the current read position of the file
         object. Returns the amount of padding which occurs after the tag, but
-        before the audio content.  A return valule of 0 does not mean error."""
+        before the audio content.  A return value of 0 does not mean error."""
         self.clear()
 
         padding_size = 0

--- a/eyed3/mp3/headers.py
+++ b/eyed3/mp3/headers.py
@@ -431,8 +431,8 @@ class LameHeader(dict):
            gain -= 6
     \endcode
 
-    Radio and Audiofile Replay Gain are often referrered to as Track and Album
-    gain, respectively.  See http://replaygain.hydrogenaudio.org/ for futher
+    Radio and Audiofile Replay Gain are often referred to as Track and Album
+    gain, respectively.  See http://replaygain.hydrogenaudio.org/ for further
     details on Replay Gain.
 
     See http://gabriel.mp3-tech.org/mp3infotag.html for the gory details of the

--- a/eyed3/utils/__init__.py
+++ b/eyed3/utils/__init__.py
@@ -239,7 +239,7 @@ GB_UNIT = "GB"
 
 
 def formatSize(size, short=False):
-    """Format ``size`` (nuber of bytes) into string format doing KB, MB, or GB
+    """Format ``size`` (number of bytes) into string format doing KB, MB, or GB
     conversion where necessary.
 
     When ``short`` is False (the default) the format is smallest unit of
@@ -410,7 +410,7 @@ def makeUniqueFileName(file_path, uniq=''):
     """The ``file_path`` is the desired file name, and it is returned if the
     file does not exist. In the case that it already exists the path is
     adjusted to be unique. First, the ``uniq`` string is added, and then
-    a couter is used to find a unique name."""
+    a counter is used to find a unique name."""
 
     path = os.path.dirname(file_path)
     file = os.path.basename(file_path)

--- a/eyed3/utils/prompt.py
+++ b/eyed3/utils/prompt.py
@@ -27,7 +27,7 @@ def parseIntList(resp):
 
 def prompt(msg, default=None, required=True, type_=str,
            validate=None, choices=None):
-    """Prompt user for imput, the prequest is in ``msg``. If ``default`` is
+    """Prompt user for input, the prequest is in ``msg``. If ``default`` is
     not ``None`` it will be displayed as the default and returned if not
     input is entered. The value ``None`` is only returned if ``required`` is
     ``False``. The response is passed to ``type_`` for conversion (default


### PR DESCRIPTION
There are small typos in:
- docs/plugins/classic_plugin.rst
- docs/plugins/fixup_plugin.rst
- eyed3/id3/frames.py
- eyed3/mp3/headers.py
- eyed3/utils/__init__.py
- eyed3/utils/prompt.py

Fixes:
- Should read `value` rather than `valule`.
- Should read `traditional` rather than `traditinal`.
- Should read `referred` rather than `referrered`.
- Should read `number` rather than `nuber`.
- Should read `input` rather than `imput`.
- Should read `individual` rather than `invidual`.
- Should read `further` rather than `futher`.
- Should read `counter` rather than `couter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md