### PR TITLE
Use poetry-core build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 
 [tool.regarding]


### PR DESCRIPTION
Replace the deprecated poetry.masonry.api build backend with the more modern poetry.core.masonry.api that avoids unnecessarily installing whole poetry when building wheels.  The rationale is provided
on the project page: https://pypi.org/project/poetry-core/