### PR TITLE
Fix dependency on `coverage` to be conditional to `test` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ check-manifest = {version = "^0.45", optional = true}
 
 [tool.poetry.extras]
 test = ["pytest", "pytest-cov", "tox", "factory-boy", "flake8",
-        "check-manifest"]
+        "check-manifest", "coverage"]
 yaml-plugin = ["ruamel.yaml"]
 art-plugin = ["Pillow", "pylast", "requests"]
 


### PR DESCRIPTION
Fix the Poetry dependency specification to include `coverage` in the `test` extra.  Otherwise, `optional = true` is ignored and an unconditional dependency is created.  Furthermore, using `optional` without an `extra` is considered incorrect and may cause Poetry to error out in the future, cf.:
https://github.com/python-poetry/poetry/issues/2357