### PR TITLE
mimetypes: Use super() in MagicTypes.__init__

### DIFF
--- a/eyed3/plugins/mimetype.py
+++ b/eyed3/plugins/mimetype.py
@@ -15,7 +15,7 @@ try:
 
     class MagicTypes(magic.Magic):
         def __init__(self):
-            magic.Magic.__init__(self, mime=True, mime_encoding=False, keep_going=True)
+            super().__init__(mime=True, mime_encoding=False, keep_going=True)
 
         def guess_type(self, filename, all_types=False):
             try:


### PR DESCRIPTION
Simplify the superclass initialization in
`MagicTypes.__init__()` by using `super()`.
Don't pass `self` as an (incorrect!) argument.

The superclass initalization previously passed `self` as the first argument, which  under Python 3.13 causes a traceback:

```text
eyed3.plugins:ERROR: Bad plugin ('mimetype.py', '/usr/lib/python3.13/site-packages/eyed3/plugins')
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/eyed3/plugins/__init__.py", line 56, in load
    mod = __import__(mod_name, globals=globals(), locals=locals())
  File "/usr/lib/python3.13/site-packages/eyed3/plugins/mimetype.py", line 33, in <module>
    _python_magic = MagicTypes()
  File "/usr/lib/python3.13/site-packages/eyed3/plugins/mimetype.py", line 18, in __init__
    magic.Magic.__init__(self, mime=True, mime_encoding=False, keep_going=True)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Magic.__init__() got an unexpected keyword argument 'mime'
```

...Because the `self` argument is actually interpreted as a _positional_ argument for `mime`, and the keyword use that follows then becomes a redundant second `mime` argument.