### PR TITLE
Add support for iTunes MVNM and MVIN frames.

### DIFF
--- a/eyed3/id3/apple.py
+++ b/eyed3/id3/apple.py
@@ -10,6 +10,8 @@ TKWD_FID = b"TKWD"
 TDES_FID = b"TDES"
 TGID_FID = b"TGID"
 GRP1_FID = b"GRP1"
+MVNM_FID = b"MVNM"
+MVIN_FID = b"MVIN"
 
 
 class PCST(Frame):
@@ -56,3 +58,15 @@ class GRP1(TextFrame):
 
     def __init__(self, _=None, **kwargs):
         super().__init__(GRP1_FID, **kwargs)
+
+class MVNM(TextFrame):
+    """Movement name. An Apple extension for classical music."""
+
+    def __init__(self, _=None, **kwargs):
+        super().__init__(MVNM_FID, **kwargs)
+
+class MVIN(TextFrame):
+    """Movement index (e.g. "3/9"). An Apple extension for classical music."""
+
+    def __init__(self, _=None, **kwargs):
+        super().__init__(MVIN_FID, **kwargs)

--- a/eyed3/id3/frames.py
+++ b/eyed3/id3/frames.py
@@ -319,7 +319,8 @@ class TextFrame(Frame):
     @staticmethod
     def isValidFrameId(fid: bytes) -> bool:
         return (fid[0:1] == b'T' or
-                fid in [b"XSOA", b"XSOP", b"XSOT", b"XDOR", b"WFED", b"GRP1"])
+                fid in [b"XSOA", b"XSOP", b"XSOT", b"XDOR", b"WFED", b"GRP1",
+                        b"MVNM", b"MVIN"])
 
 
 class UserTextFrame(TextFrame):
@@ -2254,4 +2255,8 @@ NONSTANDARD_ID3_FRAMES = {
               ID3_V2, TextFrame),
     b"GRP1": ("iTunes extension; grouping.",
               ID3_V2, apple.GRP1),
+    b"MVNM": ("iTunes extension; movement name.",
+              ID3_V2, apple.MVNM),
+    b"MVIN": ("iTunes extension; movement index.",
+              ID3_V2, apple.MVIN)
 }


### PR DESCRIPTION
For some years now, iTunes has had specific non-standard ID3 tag frames for classical music: `MVNM` (MoVement NaMe) and `MVIN` (MoVement INdex). This pull request prevents Eyed3 from erroring out when encountering those.

Also mentioned here: https://github.com/mono/taglib-sharp/issues/341
Audiobookshelf uses the tags for sorting audiobooks into series: https://www.audiobookshelf.org/docs#book-audio-metadata