### PR TITLE
remove tests from installed package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,22 @@ eyeD3 = "eyed3.main:_main"
 python = "^3.8"
 filetype = "^1.0.7"
 deprecation = "^2.1.0"
-# yaml-plugin extra
+
+[tool.poetry.extras]
+test = ["pytest", "pytest-cov", "tox", "factory-boy", "flake8",
+        "check-manifest", "coverage"]
+yaml-plugin = ["ruamel.yaml"]
+art-plugin = ["Pillow", "pylast", "requests"]
+
+[tool.poetry.group.yaml-plugin.dependencies]
 "ruamel.yaml" = {version = "^0.16.12", optional = true}
-# art-plugin extra
+
+[tool.poetry.group.art-plugin.dependencies]
 Pillow = {version = ">=8.0.1,<11.0.0", optional = true}
 pylast = {version = "^4.0.0", optional = true}
 requests = {version = "^2.25.0", optional = true}
-# Test extra
+
+[tool.poetry.group.test.dependencies]
 pytest = {version = "^6.2.1", optional = true}
 coverage = {version = "^5.3.1", optional = true, extras = ["toml"]}
 pytest-cov = {version = "^2.10.1", optional = true}
@@ -72,12 +81,6 @@ tox = {version = "^3.20.1", optional = true}
 factory-boy = {version = "^3.1.0", optional = true}
 flake8 = {version = "^3.8.4", optional = true}
 check-manifest = {version = "^0.45", optional = true}
-
-[tool.poetry.extras]
-test = ["pytest", "pytest-cov", "tox", "factory-boy", "flake8",
-        "check-manifest", "coverage"]
-yaml-plugin = ["ruamel.yaml"]
-art-plugin = ["Pillow", "pylast", "requests"]
 
 [tool.poetry.group.dev.dependencies]
 # FIXME: https://github.com/nicfit/eyeD3/issues/615

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ include = [
     "README.rst", "LICENSE", "Makefile", "requirements.txt", "MANIFEST.in",
     "AUTHORS.rst", "CONTRIBUTING.rst", "HISTORY.rst",
     "tox.ini",
-    "tests/**/*.py",
     "docs/",
     "requirements/*.txt",
     "examples/*",
@@ -49,6 +48,7 @@ include = [
 ]
 exclude = [
     "docs/_build",
+    "tests*",
 ]
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,17 +37,17 @@ packages = [
     {include = "eyed3"},
 ]
 include = [
-    "poetry.lock",
-    "README.rst", "LICENSE", "Makefile", "requirements.txt", "MANIFEST.in",
-    "AUTHORS.rst", "CONTRIBUTING.rst", "HISTORY.rst",
-    "tox.ini",
-    "docs/",
-    "requirements/*.txt",
-    "examples/*",
     "eyed3/plugins/DisplayPattern.ebnf",
 ]
 exclude = [
+    "poetry.lock",
+    "README.rst", "LICENSE", "Makefile", "requirements.txt", "MANIFEST.in",
+    "AUTHORS.rst", "CONTRIBUTING.rst", "HISTORY.rst",
+    "requirements/*.txt",
+    "tox.ini",
+    "docs/",
     "docs/_build",
+    "examples/*",
     "tests*",
 ]
 


### PR DESCRIPTION
The package should not pollute the environment under which it gets installed.

The way the `pyproject.toml` file was defined, all these package-specific files were dumped *directly* under `site-packages` of the python environment, not under `site-packages/eyeD3`. These files are not relevant to the python execution, and should not be in `site-packages` at all. 