### PR TITLE
Skip tests if the data directory isn't found

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,7 @@ def _tempCopy(src, dest_dir) -> Path:
 def audiofile(request, tmpdir):
     """Makes a copy of test.mp3 and loads it using eyed3.load()."""
     if not Path(DATA_D).exists():
-        yield None
-        return
+        pytest.skip("data directory not found")
 
     marker = request.node.get_closest_marker("audiofile_name")
     if marker:


### PR DESCRIPTION
If the user hasn't populated the tests/data directory, they get test failures because the fixture yields None, and then tries to call methods on an object that is None. This feels like an anti-pattern, so use pytest.skip to make the testcase skip instead.