### PR TITLE
tests: mark more tests to skip when DATA_D is not available

### DIFF
--- a/tests/id3/test_rva.py
+++ b/tests/id3/test_rva.py
@@ -1,8 +1,10 @@
 import dataclasses
+from pathlib import Path
 import pytest
 from pytest import approx
 from eyed3.id3 import ID3_V2_3, ID3_V2_4, ID3_V2_2
 from eyed3.id3.frames import RelVolAdjFrameV23, RelVolAdjFrameV24, FrameException, FrameHeader
+from .. import DATA_D
 
 
 def test_default_v23():
@@ -184,6 +186,7 @@ def test_default_v24():
     assert f2.peak == 666
 
 
+@pytest.mark.skipif(not Path(DATA_D).exists(), reason="test requires data files")
 def test_RVAD_RVA2(audiofile):
     # RVAD -> *RVA2
     audiofile.initTag(version=ID3_V2_3)

--- a/tests/test_classic_plugin.py
+++ b/tests/test_classic_plugin.py
@@ -868,6 +868,7 @@ def test_removeTagWithBoth_v1_withConvert(audiofile, eyeD3):
     assert v2_tag is not None and v2_tag.artist == "Poison Idea"
 
 
+@pytest.mark.skipif(not Path(DATA_D).exists(), reason="test requires data files")
 def test_clearGenre(audiofile, eyeD3):
     audiofile = eyeD3(audiofile, ["--genre=Rock"])
     assert audiofile.tag.genre.name, audiofile.tag.genre.name == ("Rock", 17)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -60,6 +60,7 @@ def testIssue76(audiofile):
     assert tag.getTextFrame("TSOP") == "In the name of suffering"
 
 
+@pytest.mark.skipif(not Path(DATA_D).exists(), reason="test requires data files")
 def test_issue382_genres(audiofile):
     """Tags always written in v2.3 format, always including ID.
     https://github.com/nicfit/eyeD3/issues/382

--- a/tests/test_jsonyaml_plugin.py
+++ b/tests/test_jsonyaml_plugin.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import stat
+from pathlib import Path
+import pytest
 from eyed3 import main, version
-from . import RedirectStdStreams
+from . import DATA_D, RedirectStdStreams
 
 
 def _initTag(afile):
@@ -34,6 +36,7 @@ def _assertFormat(plugin: str, audio_file, format: str):
                                                    size_bytes=size_bytes)
 
 
+@pytest.mark.skipif(not Path(DATA_D).exists(), reason="test requires data files")
 def testJsonPlugin(audiofile):
     _initTag(audiofile)
     _assertFormat("json", audiofile, """
@@ -58,6 +61,7 @@ def testJsonPlugin(audiofile):
 """)
 
 
+@pytest.mark.skipif(not Path(DATA_D).exists(), reason="test requires data files")
 def testYamlPlugin(audiofile):
     _initTag(audiofile)
 


### PR DESCRIPTION
Running the tests locally, a few failed because they require external files.