### PR TITLE
fix: align output from classic plugin

### DIFF
--- a/eyed3/plugins/__init__.py
+++ b/eyed3/plugins/__init__.py
@@ -134,10 +134,13 @@ class Plugin(utils.FileHandler):
         file_size = path.stat().st_size
         path_str = str(path)
         size_str = formatSize(file_size)
-        size_len = len(size_str) + 5
+        size_len = len(size_str) + 4
         if len(path_str) + size_len >= width:
             path_str = "..." + str(path)[-(75 - size_len):]
         padding_len = width - len(path_str) - size_len
+        # ensure padding_len greater than 0
+        if padding_len <= 0:
+            padding_len = 1
 
         return "{path}{color}{padding}[ {size} ]{reset}"\
                .format(path=boldText(path_str, c=HEADER_COLOR()),

--- a/eyed3/utils/console.py
+++ b/eyed3/utils/console.py
@@ -482,7 +482,7 @@ def getTtySize(fd=sys.stdout, check_tty=True):
             hw = (int(os.environ.get('LINES')),
                   int(os.environ.get('COLUMNS')))
         except (TypeError, ValueError):
-            hw = (78, 25)
+            hw = (25, 79)
     return hw
 
 


### PR DESCRIPTION
A number of minor issues crept in as the output plugins were refactored.

Ensure `padding_len` is greater than 0.  When calculating the terminal width, if the output is piped, we can end up with a negative padding length.  This results in no space between the filename the size.  Set `padding_len` to a minimum of 1.

The `-` lines printed by `_getHardRule()` are too short when output is not to a terminal, i.e.: when sending to a pager.  This turns out to be due to the LINES and COLUMNS being transposed in `getTtySize`.  When the terminal size cannot be determined, we want to set it to something like 80x24 (COLUMNS x LINES), but instead we set it to 25x78, which results in very short lines from `_getHardRule()`.  Fix the transposition and adjust the values to 79x25 which ensures the output is aligned with `printAudioInfo()`.  The audio info line uses two hard tabs and has a minimum width of 79 COLUMNS.

Fix an off-by-one in the `size_len` var in `_getFileHeader()`.  We add 4 characters (`[ ` & ` ]`) rather than 5.  This was added in 599eddd (display the ellipsis file name and path, and the file size right justified in printHeader., 2015-10-20), released in 0.7.9.

The output is now neatly aligned when output is not directly to a terminal:

$ eyeD3 ~/mp3/tool/ænima/13-ænema.mp3 | cat
/home/foo/mp3/tool/ænima/13-ænema.mp3                              [ 14.50 MB ]
-------------------------------------------------------------------------------
Time: 06:40	MPEG1, Layer III	[ ~278 kb/s @ 44100 Hz - Joint stereo ]
-------------------------------------------------------------------------------