### PR TITLE
fix: classic plugin: decode ufid.owner_id for display

### DIFF
--- a/eyed3/plugins/classic.py
+++ b/eyed3/plugins/classic.py
@@ -620,7 +620,8 @@ optional. For example, 2012-03 is valid, 2012--12 is not.
             # UFID
             for ufid in tag.unique_file_ids:
                 printMsg("%s [%s] : %s" %
-                        (boldText("Unique File ID:"), ufid.owner_id,
+                        (boldText("Unique File ID:"),
+                         ufid.owner_id.decode("unicode_escape"),
                          ufid.uniq_id.decode("unicode_escape")))
 
             # COMM


### PR DESCRIPTION
When printing UFID frames, the classic plugin does not decode `owner-id`:

    Unique File ID: [b'https://musicbrainz.org'] : be36bad3...

Decode `owner-id` as we do for `id`.