### PR TITLE
fix: handle BrokenPipeError

### DIFF
--- a/eyed3/main.py
+++ b/eyed3/main.py
@@ -277,6 +277,12 @@ def _main():
         retval = mainFunc(args, config)
     except KeyboardInterrupt:
         retval = 0
+    except BrokenPipeError:
+        # Python flushes standard streams on exit; redirect remaining output
+        # to devnull to avoid another BrokenPipeError at shutdown
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        retval = 1
     except (StopIteration, IOError) as ex:
         eyed3.utils.console.printError(str(ex))
         retval = 1


### PR DESCRIPTION
When piping eyeD3's output to another command, python throws a BrokenPipeError, resulting in this ugly trailing output:

    [Errno 32] Broken pipe
    Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
    BrokenPipeError: [Errno 32] Broken pipe

Catch BrokenPipeError using the method documented here:

    https://docs.python.org/3/library/signal.html#note-on-sigpipe