### PR TITLE
Resolve logger warnings

### DIFF
--- a/eyed3/id3/tag.py
+++ b/eyed3/id3/tag.py
@@ -174,7 +174,7 @@ class Tag(core.Tag):
                 self.release_date = int(year)
         except ValueError:
             # Bogus year strings.
-            log.warn("ID3v1.x tag contains invalid year: %s" % year)
+            log.warning("ID3v1.x tag contains invalid year: %s" % year)
             pass
 
         # Can't use ID3_V1_STRIP_CHARS here, since the final byte is numeric
@@ -535,7 +535,7 @@ class Tag(core.Tag):
     The date the work was originally released.
 
     NOTE: ID3v2.3 only stores year. If the Date object is more precise it is store in `XDOR`, and
-    XDOR is preferred when acessing. The year-only date is stored in the standard `TORY` frame as
+    XDOR is preferred when accessing. The year-only date is stored in the standard `TORY` frame as
     well.
     """)
 
@@ -1845,7 +1845,7 @@ class ChaptersAccessor(AccessorBase):
         return super().get(element_id)
 
     def __getitem__(self, elem_id):
-        """Overiding the index based __getitem__ for one indexed with chapter
+        """Overriding the index based __getitem__ for one indexed with chapter
         element IDs. These are stored in the tag's table of contents frames."""
         for chapter in (self._fs[frames.CHAPTER_FID] or []):
             if chapter.element_id == elem_id:
@@ -1905,7 +1905,7 @@ class TocAccessor(AccessorBase):
         return super().get(element_id)
 
     def __getitem__(self, elem_id):
-        """Overiding the index based __getitem__ for one indexed with table
+        """Overriding the index based __getitem__ for one indexed with table
         of contents element IDs."""
         for toc in (self._fs[frames.TOC_FID] or []):
             if toc.element_id == elem_id:


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.