### PR TITLE
Fix links in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,16 +90,16 @@ Get Started
 Python >= 3.9 is required.
 
 For `installation instructions`_ or more complete `documentation`_ see
-http://eyeD3.nicfit.net/
+https://eyed3.readthedocs.io/
 
 Please post feedback and/or defects on the `issue tracker`_, or `mailing list`_.
 
-.. _eyeD3: http://eyeD3.nicfit.net/
+.. _eyeD3: https://eyed3.readthedocs.io/
 .. _Travis Shirk: travis@pobox.com
 .. _issue tracker: https://github.com/nicfit/eyeD3/issues
 .. _mailing list: https://groups.google.com/forum/?fromgroups#!forum/eyed3-users
-.. _installation instructions: http://eyeD3.nicfit.net/index.html#installation
-.. _documentation: http://eyeD3.nicfit.net/index.html#documentation
+.. _installation instructions: https://eyed3.readthedocs.io/en/latest/installation.html
+.. _documentation: https://eyed3.readthedocs.io/
 .. _GPL: http://www.gnu.org/licenses/gpl-2.0.html
 .. _ID3: http://id3.org/
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,7 +70,7 @@ Or you can run from the archive directory directly:
     $ export PYTHONPATH=`pwd`/build/lib
     $ export PATH=${PATH}:`pwd`/bin
 
-.. _release archive: http://eyed3.nicfit.net/releases/
+.. _release archive: https://github.com/nicfit/eyeD3/releases
 
 Checking Out the Source Code
 ============================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://eyeD3.nicfit.net/"
+homepage = "https://eyed3.readthedocs.io/"
 repository = "https://github.com/nicfit/eyeD3"
 
 [project.scripts]


### PR DESCRIPTION
This updates some of the links in documentation that point to the [previous site][1] before it was changed to a redirect to readthedocs. It also updates links to releases from eyed3.nicfit.net to the GitHub repo releases as http://eyed3.nicfit.net/releases/ returns 403

[1]: https://web.archive.org/web/20150213014222/http://eyed3.nicfit.net/installation.html