### PR TITLE
Remove eyed3.utils.console.getTtySize() implementation

### DIFF
--- a/eyed3/__regarding__.py
+++ b/eyed3/__regarding__.py
@@ -22,10 +22,10 @@ class Version:
 
 
 project_name = "eyeD3"
-version = "0.9.8"
+version = "0.9.9.dev0"
 version_info = Version(
-    0, 9, 8,
-    None,
+    0, 9, 9,
+    0,
     None,
     None,
     "Armed & Dangerous",
@@ -35,7 +35,7 @@ author = "Travis Shirk"
 author_email = "travis@pobox.com"
 years = "2002-2025"
 description = "Python audio data toolkit (ID3 and MP3)"
-homepage = "https://eyeD3.nicfit.net/"
+homepage = "https://eyed3.readthedocs.io/"
 
 
 def versionBanner() -> str:

--- a/eyed3/plugins/classic.py
+++ b/eyed3/plugins/classic.py
@@ -1,6 +1,7 @@
 import os
 import re
 import dataclasses
+import shutil
 from functools import partial
 from argparse import ArgumentTypeError
 
@@ -8,7 +9,7 @@ from eyed3.plugins import LoaderPlugin
 from eyed3 import core, id3, mp3
 from eyed3.utils import makeUniqueFileName, b, formatTime
 from eyed3.utils.console import (
-    printMsg, printError, printWarning, boldText, getTtySize,
+    printMsg, printError, printWarning, boldText,
 )
 from eyed3.id3.frames import ImageFrame
 from eyed3.mimetype import guessMimetype
@@ -444,7 +445,7 @@ optional. For example, 2012-03 is valid, 2012--12 is not.
         if not self.audio_file:
             return
 
-        self.terminal_width = getTtySize()[1]
+        self.terminal_width = shutil.get_terminal_size()[1]
         self.printHeader(f)
 
         if self.audio_file.tag and self.handleRemoves(self.audio_file.tag):

--- a/eyed3/plugins/lameinfo.py
+++ b/eyed3/plugins/lameinfo.py
@@ -1,6 +1,8 @@
 import math
+import shutil
+
 from eyed3.utils import formatSize
-from eyed3.utils.console import printMsg, getTtySize
+from eyed3.utils.console import printMsg
 from eyed3.plugins import LoaderPlugin
 
 
@@ -16,7 +18,7 @@ class LameInfoPlugin(LoaderPlugin):
        )
 
     def printHeader(self, file_path):
-        w = getTtySize()[1]
+        w = shutil.get_terminal_size()[1]
         printMsg(self._getFileHeader(file_path, w))
         printMsg(self._getHardRule(w))
 

--- a/eyed3/utils/console.py
+++ b/eyed3/utils/console.py
@@ -1,13 +1,14 @@
 import os
-import struct
 import sys
 import time
 import typing
+import shutil
 from typing import Union
 
+import deprecation
+from ..__about__ import __version__
+
 try:
-    import fcntl
-    import termios
     import signal
     _CAN_RESIZE_TERMINAL = True
 except ImportError:
@@ -277,8 +278,7 @@ class ProgressBar(object):
         self.update(0)
 
     def _handle_resize(self, signum=None, frame=None):
-        self._terminal_width = getTtySize(self._file,
-                                          self._should_handle_resize)[1]
+        self._terminal_width = shutil.get_terminal_size()[1]
 
     def __enter__(self):
         return self
@@ -469,21 +469,10 @@ def cformat(msg, fg, bg=None, styles=None):
     return output
 
 
+@deprecation.deprecated(deprecated_in="0.9.9", removed_in="1.0", current_version=__version__,
+                        details="Use shutil.get_terminal_size() instead.")
 def getTtySize(fd=sys.stdout, check_tty=True):
-    hw = None
-    if check_tty:
-        try:
-            data = fcntl.ioctl(fd, termios.TIOCGWINSZ, '\0' * 4)
-            hw = struct.unpack("hh", data)
-        except (OSError, NameError):
-            pass
-    if not hw:
-        try:
-            hw = (int(os.environ.get('LINES')),
-                  int(os.environ.get('COLUMNS')))
-        except (TypeError, ValueError):
-            hw = (25, 79)
-    return hw
+    return shutil.get_terminal_size()  # Added in Python 3.3
 
 
 def cprint(msg, fg, bg=None, styles=None, file=sys.stdout):


### PR DESCRIPTION
`shutil.get_terminal_size()` was added in Python 3.3, use it instead.

Fixes #680 