### PR TITLE
fix image frame description

### DIFF
--- a/eyed3/id3/frames.py
+++ b/eyed3/id3/frames.py
@@ -635,8 +635,6 @@ class ImageFrame(Frame):
             self.picture_type = pt
         log.debug("APIC picture type: %d" % self.picture_type)
 
-        self.description = ""
-
         # Remaining data is a NULL separated description and image data
         buffer = input.read()
         input.close()

--- a/eyed3/id3/frames.py
+++ b/eyed3/id3/frames.py
@@ -635,7 +635,7 @@ class ImageFrame(Frame):
             self.picture_type = pt
         log.debug("APIC picture type: %d" % self.picture_type)
 
-        self.desciption = ""
+        self.description = ""
 
         # Remaining data is a NULL separated description and image data
         buffer = input.read()


### PR DESCRIPTION
`description` is spelled wrong and gets set a few lines later anyways. So we could either keep it like this:

https://github.com/vlt/eyeD3/blob/0ad57cf49809af9cc3ea812b47886a7560803c9b/eyed3/id3/frames.py#L637-L648

or delete it ;-)