### PR TITLE
fix terminal width

### DIFF
--- a/eyed3/plugins/classic.py
+++ b/eyed3/plugins/classic.py
@@ -447,7 +447,7 @@ optional. For example, 2012-03 is valid, 2012--12 is not.
         if not self.audio_file:
             return
 
-        self.terminal_width = shutil.get_terminal_size()[1]
+        self.terminal_width = shutil.get_terminal_size().columns
         self.printHeader(f)
 
         if self.audio_file.tag and self.handleRemoves(self.audio_file.tag):

--- a/eyed3/plugins/lameinfo.py
+++ b/eyed3/plugins/lameinfo.py
@@ -18,7 +18,7 @@ class LameInfoPlugin(LoaderPlugin):
        )
 
     def printHeader(self, file_path):
-        w = shutil.get_terminal_size()[1]
+        w = shutil.get_terminal_size().columns
         printMsg(self._getFileHeader(file_path, w))
         printMsg(self._getHardRule(w))
 

--- a/eyed3/utils/console.py
+++ b/eyed3/utils/console.py
@@ -278,7 +278,7 @@ class ProgressBar(object):
         self.update(0)
 
     def _handle_resize(self, signum=None, frame=None):
-        self._terminal_width = shutil.get_terminal_size()[1]
+        self._terminal_width = shutil.get_terminal_size().columns
 
     def __enter__(self):
         return self


### PR DESCRIPTION
0f81cd1 (Remove eyed3.utils.console.getTtySize() implementation (#682), 2025-10-22) didn't take into account the difference in the order of the tuple contents.  As a result, it now returns the terminal height when it intends to return the width.

To demonstrate:

    $ python -c 'print();
    import shutil; from eyed3.utils.console import getTtySize;
    print(shutil.get_terminal_size());
    print(tuple(shutil.get_terminal_size()));
    print(getTtySize())
    '

    os.terminal_size(columns=80, lines=24)
    (80, 24)
    (24, 80)

Fortunately, the output from shutil.get_terminal_size() is a named tuple.  Use the `os.terminal_size` field names rather than slicing to get the terminal width in several locations.  This makes the code clearer and less likely to accidentally transpose the height and width.

Fixes #689