### PR TITLE
Fix Python 3.15 compatibility: strptime no longer allows %d without %Y

### DIFF
--- a/eyed3/core.py
+++ b/eyed3/core.py
@@ -372,7 +372,14 @@ class Date:
         pdate, fmt = None, None
         for fmt in Date.TIME_STAMP_FORMATS:
             try:
-                pdate = time.strptime(s, fmt)
+                if "%d" in fmt and "%Y" not in fmt:
+                    # Python 3.15+ no longer allows %d without %Y in strptime
+                    # (see https://github.com/python/cpython/issues/70647).
+                    # Prepend a dummy year to satisfy the requirement; the year
+                    # value is never extracted because "%Y" is not in fmt.
+                    pdate = time.strptime("2000" + s, "%Y" + fmt)
+                else:
+                    pdate = time.strptime(s, fmt)
                 break
             except ValueError:
                 # date string did not match format.


### PR DESCRIPTION
Python 3.15 removed support for using the %d (day of month) directive without a %Y (year) directive in time.strptime(), raising ValueError instead (https://github.com/python/cpython/issues/70647).

The "D%d-%m" format in TIME_STAMP_FORMATS is used to parse day-month strings for ID3v2.3 TDAT frames. Work around the restriction by prepending a dummy year for the strptime call; the year value is never extracted because "%Y" is not in the original format string.

Assisted-by: Cursor