### PR TITLE
fix: TDAT/TIME frames lose month/day/time when day or hour < 10 in ID3v2.3

### DIFF
--- a/eyed3/id3/frames.py
+++ b/eyed3/id3/frames.py
@@ -381,6 +381,12 @@ class DateFrame(TextFrame):
 
     def parse(self, data, frame_header):
         super().parse(data, frame_header)
+        # TDAT uses raw DDMM format and TIME uses raw HHmm format — neither is
+        # ISO-8601, so skip the ISO validation step for these two frame types.
+        # Their values are consumed by _getV23RecordingDate() which reads the
+        # raw text directly, so preserving the text as-is is correct.
+        if self.id in (b"TDAT", b"TIME"):
+            return
         try:
             if self.text:
                 _ = core.Date.parse(self.text)                        # noqa

--- a/tests/id3/test_tag.py
+++ b/tests/id3/test_tag.py
@@ -1286,3 +1286,38 @@ def testRecordingDate_v23_issue517(id3tag, eyed3_version):
         assert id3tag.recording_date.year == d.year
         assert id3tag.recording_date.month is None
         assert id3tag.recording_date.day is None
+
+
+def testRecordingDate_v23_single_digit_day_hour(tmpdir):
+    """TDAT (DDMM) and TIME (HHmm) frames with leading-zero values must
+    survive a save/reload round-trip when the day or hour is < 10.
+
+    Previously DateFrame.parse() called core.Date.parse() to validate TDAT and
+    TIME text, but those frames store raw 'DDMM'/'HHmm' values that are not
+    ISO-8601.  A value like '0501' (day 5, month 1) was mis-parsed as year 501,
+    which then failed Date's own self-validation and caused parse() to silently
+    clear the frame text, losing the month/day/time information entirely.
+    """
+    import tempfile, os
+
+    cases = [
+        Date(2023, 1, 5, 9, 5),    # single-digit day and hour
+        Date(2023, 1, 5, 9, 15),   # single-digit day, two-digit minute
+        Date(2023, 1, 5, 19, 5),   # two-digit hour, single-digit minute
+        Date(2023, 1, 15, 9, 5),   # two-digit day, single-digit hour
+        Date(2023, 10, 5, 9, 5),   # two-digit month, single-digit day+hour
+    ]
+
+    for d in cases:
+        tmpfile = str(tmpdir.join("test.mp3"))
+        tag = Tag()
+        tag.file_info = type("obj", (object,), {"name": tmpfile})()
+        tag.recording_date = d
+        with open(tmpfile, "wb") as f:
+            f.write(b"\xff\xfb\x90\x00" * 10)
+        tag.save(tmpfile, version=ID3_V2_3)
+
+        af = eyed3.load(tmpfile)
+        assert af.tag.recording_date == d, (
+            f"round-trip failed for {d}: got {af.tag.recording_date}"
+        )


### PR DESCRIPTION
## What breaks

When saving an ID3v2.3 tag whose recording date has a single-digit day (1–9) or
hour (0–9), the month, day, and time are silently dropped on the next load.

```python
import eyed3, tempfile, os
from eyed3.id3 import Tag, ID3_V2_3
from eyed3 import core

tmpfile = tempfile.mktemp(suffix='.mp3')
tag = Tag()
tag.file_info = type('obj', (object,), {'name': tmpfile})()
tag.recording_date = core.Date(2023, 1, 5, 9, 5)   # day=5, hour=9

with open(tmpfile, 'wb') as f:
    f.write(b'\xff\xfb\x90\x00' * 10)
tag.save(tmpfile, version=ID3_V2_3)

af = eyed3.load(tmpfile)
print(af.tag.recording_date)   # prints "2023" instead of "2023-01-05T09:05"
# warnings: "Invalid date: 0501" / "Invalid date: 0905"
```

Related to issues #139, #517, #542 (all share the same root cause).

## Root cause

ID3v2.3 stores dates across three frames: `TYER` (YYYY), `TDAT` (DDMM), and
`TIME` (HHmm).  `DateFrame.parse()` validates the text of *every* date frame by
calling `core.Date.parse()`, which only understands ISO-8601.

A TDAT value of `"0501"` (day 05, month 01) is accidentally matched by the
`"%Y"` strptime format as year 501.  `Date(year=501)` then fails its own
self-validation (`str(Date(501))` → `"501"`, not a four-digit year), raising
`ValueError`.  `DateFrame.parse()` catches that exception and clears
`self.text = ""`.  With TDAT empty, `_getV23RecordingDate()` cannot
reconstruct the month/day, so `recording_date` reports only the year.

## Fix

Skip the ISO-8601 validation step for `TDAT` and `TIME` frames only.
`_getV23RecordingDate()` already handles their raw DDMM/HHmm encoding
correctly; preserving the raw text is sufficient.

```diff
 def parse(self, data, frame_header):
     super().parse(data, frame_header)
+    if self.id in (b"TDAT", b"TIME"):
+        return  # DDMM/HHmm format, not ISO-8601
     try:
         if self.text:
             _ = core.Date.parse(self.text)
```

## Tests

A new parameterised test `testRecordingDate_v23_single_digit_day_hour` in
`tests/id3/test_tag.py` verifies save/reload round-trips for five dates that
all have a single-digit day or hour.  All 42 + 1 existing/new tests pass.

---
This pull request was prepared with the assistance of AI, under my direction and review.