### PR TITLE
Fix typos in docstrings and comments

### DIFF
--- a/eyed3/id3/__init__.py
+++ b/eyed3/id3/__init__.py
@@ -102,7 +102,7 @@ def versionToString(v):
 
 
 class GenreException(Error):
-    """Excpetion type for exceptions related to genres."""
+    """Exception type for exceptions related to genres."""
 
 
 @functools.total_ordering
@@ -171,8 +171,8 @@ class Genre:
     def name(self):
         """The Genre's name property.
         When setting the value the name is looked up in the standard genre
-        map and if found the ``id`` ppropery is set to the numeric valud **and**
-        the name is normalized to the sting found in the map. Non standard
+        map and if found the ``id`` property is set to the numeric value **and**
+        the name is normalized to the string found in the map. Non standard
         genres are set (with a warning log) and the ``id`` is set to ``None``.
         It is valid to set the value to ``None``.
         """

--- a/eyed3/id3/headers.py
+++ b/eyed3/id3/headers.py
@@ -96,7 +96,7 @@ class TagHeader(object):
                                                    self.footer))
 
         # 4 bytes: The size of the extended header (if any), frames, and padding
-        # afer unsynchronization. This is a sync safe integer, so only the
+        # after unsynchronization. This is a sync safe integer, so only the
         # bottom 7 bits of each byte are used.
         tag_size_bytes = f.read(4)
         if len(tag_size_bytes) != 4:
@@ -374,7 +374,7 @@ class ExtendedTagHeader(object):
 
         return data
 
-    # Only call this when you *know* there is an extened header.
+    # Only call this when you *know* there is an extended header.
     def parse(self, fp, version):
         '''Parse an ID3 v2 extended header starting at the current position
         of ``fp`` and per the format defined by ``version``. This method

--- a/eyed3/plugins/classic.py
+++ b/eyed3/plugins/classic.py
@@ -1126,7 +1126,7 @@ ARGS_HELP = {
         "--write-objects": "Causes all attached objects (GEOB frames) to be "
                            "written to the specified directory.",
 
-        "--add-popularity": "Adds a pupularity metric. There may be multiples "
+        "--add-popularity": "Adds a popularity metric. There may be multiples "
                            "popularity values, but each must have a unique "
                            "email address component. The rating is a number "
                            "between 0 (worst) and 255 (best). The play count "
@@ -1168,6 +1168,6 @@ ARGS_HELP = {
         "--track-offset": "Increment/decrement the track number by [-]N. "
                           "This option is applied after --track=N is set.",
         "--composer": "Set the composer's name.",
-        "--orig-artist": "Set the orignal artist's name. For example, a cover song can include "
-                         "the orignal author of the track.",
+        "--orig-artist": "Set the original artist's name. For example, a cover song can include "
+                         "the original author of the track.",
 }

--- a/eyed3/plugins/fixup.py
+++ b/eyed3/plugins/fixup.py
@@ -591,7 +591,7 @@ Album types:
                     printMsg("Renaming directory to %s" % dir_rename[1])
                     s = os.stat(dir_rename[0])
                     os.rename(dir_rename[0], dir_rename[1])
-                    # With a rename use the origianl access time
+                    # With a rename use the original access time
                     os.utime(dir_rename[1], (s.st_atime, s.st_atime))
 
         else:

--- a/eyed3/utils/__init__.py
+++ b/eyed3/utils/__init__.py
@@ -169,7 +169,7 @@ def formatTime(seconds, total=None, short=False):
 
         HH:MM:SS.
 
-    Otherwise, the format is exacly 6 characters long and of the form:
+    Otherwise, the format is exactly 6 characters long and of the form:
 
         1w 3d
         2d 4h


### PR DESCRIPTION
Fix several typos found by running [codespell](https://github.com/codespell-project/codespell) over the repo. All changes are in docstrings and inline comments — no logic changed.

- `eyed3/id3/__init__.py`: `Excpetion` → `Exception` (docstring), `valud` → `value`, `sting` → `string` (docstring), also fixed `ppropery` → `property`
- `eyed3/id3/headers.py`: `afer` → `after` (comment), `extened` → `extended` (comment)
- `eyed3/plugins/classic.py`: `pupularity` → `popularity` (help string), `orignal` → `original` (help string, two occurrences)
- `eyed3/plugins/fixup.py`: `origianl` → `original` (comment)
- `eyed3/utils/__init__.py`: `exacly` → `exactly` (docstring)